### PR TITLE
Updated tensorflow import for latest version

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -6,7 +6,10 @@ from io import BytesIO
 
 import matplotlib
 import numpy as np
-import tensorflow as tf
+# import tensorflow as tf
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
+
 
 matplotlib.use('agg')
 import matplotlib.pyplot as plt

--- a/handwrite.py
+++ b/handwrite.py
@@ -34,7 +34,10 @@ else:
 import pickle
 
 import matplotlib
-import tensorflow as tf
+# import tensorflow as tf
+import tensorflow.compat.v1 as tf
+tf.disable_v2_behavior()
+
 
 import generate
 


### PR DESCRIPTION
Latest version of tensorflow does not support objects like  'ConfigProto'. I found the fix [here](https://stackoverflow.com/questions/56127592/attributeerror-module-tensorflow-has-no-attribute-configproto)  and created a PR for same. 